### PR TITLE
Don't generate NOTICE when HTTP_USER_AGENT is not set

### DIFF
--- a/download_all.php
+++ b/download_all.php
@@ -24,7 +24,11 @@ $min_version = get_str("min_version", true);
 $max_version = get_str("max_version", true);
 $version = get_str("version", true);
 $type_name = get_str("type", true);
-$client_info = $_SERVER['HTTP_USER_AGENT'];
+if ( isset($_SERVER['HTTP_USER_AGENT'] ) {
+    $client_info = $_SERVER['HTTP_USER_AGENT'];
+} else {
+    $client_info = "";
+}
 
 // if not XML, dev defaults to 1
 //


### PR DESCRIPTION
Handle request for download_all page when HTTP_USER_AGENT is not set without generating a NOTICE (which makes the xml invalid)