### PR TITLE
Update Linux instructions: recommend computer restart is having permissions issues and link our wiki page for other cases

### DIFF
--- a/linux_install.php
+++ b/linux_install.php
@@ -196,7 +196,7 @@ sudo zypper install boinc-client boinc-manager',
     echo copy_button($x, 'Copy above instructions to clipboard', 'id1');
 
     text_start(800);
-    echo "<p>If you have any permissions issues when running BOINC Manager, restart your computer.";
+    echo "<p>If you have permissions issues when running BOINC Manager, they are often caused by your user not yet being in the BOINC group or that group membership not having taken effect. Try logging out and back in (or restarting your computer) after installation or after adding your user to the BOINC group.";
     echo "<p>On headless systems, omit 'boinc-manager'.
         On such systems, the BOINC client can be
         controlled either using <a href=https://github.com/BOINC/boinc/wiki/boinccmd-tool>boinccmd</a>,

--- a/linux_install.php
+++ b/linux_install.php
@@ -196,7 +196,11 @@ sudo zypper install boinc-client boinc-manager',
     echo copy_button($x, 'Copy above instructions to clipboard', 'id1');
 
     text_start(800);
-    echo "<p>If you have permissions issues when running BOINC Manager, they are often caused by your user not yet being in the BOINC group or that group membership not having taken effect. Try logging out and back in (or restarting your computer) after installation or after adding your user to the BOINC group.";
+    echo "<p>If you have permissions issues when running BOINC Manager,
+    they are often caused by your user not yet being in the BOINC group or that
+    group membership not having taken effect. Try logging out and back in
+    (or restarting your computer) after installation or after adding your user
+    to the BOINC group.";
     echo "<p>On headless systems, omit 'boinc-manager'.
         On such systems, the BOINC client can be
         controlled either using <a href=https://github.com/BOINC/boinc/wiki/boinccmd-tool>boinccmd</a>,

--- a/linux_install.php
+++ b/linux_install.php
@@ -196,6 +196,7 @@ sudo zypper install boinc-client boinc-manager',
     echo copy_button($x, 'Copy above instructions to clipboard', 'id1');
 
     text_start(800);
+    echo "<p>If you have any permissions issues when running BOINC Manager, restart your computer.";
     echo "<p>On headless systems, omit 'boinc-manager'.
         On such systems, the BOINC client can be
         controlled either using <a href=https://github.com/BOINC/boinc/wiki/boinccmd-tool>boinccmd</a>,
@@ -319,6 +320,11 @@ function form($os_num) {
         If not, we recommend using the
         standard package manager of your Linux distro
         (apt, yum, or zypper).
+    ";
+    echo "
+        <p>
+        If you're using a different Linux distro, read instructions on our
+        <a href=https://github.com/BOINC/boinc/wiki/Installing_on_Linux>wiki page</a>.
     ";
     echo "<h2>Standard package</h2>
         <p>

--- a/linux_install.php
+++ b/linux_install.php
@@ -323,7 +323,7 @@ function form($os_num) {
     ";
     echo "
         <p>
-        If you're using a different Linux distro, read instructions on our
+        If your Linux distro isn't listed above, read the instructions on our
         <a href=https://github.com/BOINC/boinc/wiki/Installing_on_Linux>wiki page</a>.
     ";
     echo "<h2>Standard package</h2>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Clarified the Linux install page to explain that BOINC Manager permission errors usually come from missing BOINC group membership, and to advise logging out/in or rebooting after install or after adding the user. Added a link to our wiki for distros not using `apt`, `yum`, or `zypper`.

<sup>Written for commit afba081737658f04e986faac079c928455cd8920. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

