### PR TITLE
Update linux_install.php to inclulde information about the 8.2.10 alpha release

### DIFF
--- a/linux_install.php
+++ b/linux_install.php
@@ -5,7 +5,7 @@
 require_once('../inc/util.inc');
 require_once('../inc/clipboard.inc');
 
-$versions = ['stable'=>'8.2.9', 'alpha'=>'8.2.9', 'nightly'=>'8.3.0'];
+$versions = ['stable'=>'8.2.9', 'alpha'=>'8.2.10', 'nightly'=>'8.3.0'];
 
 define('OS_DEBIAN', 0);
 define('OS_UBUNTU', 1);
@@ -27,7 +27,8 @@ function get_oss($os_num) {
     case OS_UBUNTU:
         $oss[$n++] = os('Ubuntu', '20.04', 'focal', 'April 2025', '2.31');
         $oss[$n++] = os('Ubuntu', '22.04', 'jammy', 'April 2027', '2.35');
-        $oss[$n++] = os('Ubuntu', '24.04', 'noble', 'April 2034', '2.39');
+        $oss[$n++] = os('Ubuntu', '24.04', 'noble', 'April 2029', '2.39');
+//        $oss[$n++] = os('Ubuntu', '26.04', 'resolute', 'April 2031', '2.42');
         break;
     case OS_FEDORA:
         $oss[$n++] = os('Fedora', '37', 'fc37', 'November 2023', '2.36');
@@ -37,6 +38,7 @@ function get_oss($os_num) {
         $oss[$n++] = os('Fedora', '41', 'fc41', 'November 2025', '2.40');
         $oss[$n++] = os('Fedora', '42', 'fc42', 'May 2026', '2.41');
         $oss[$n++] = os('Fedora', '43', 'fc43', 'December 2026', '2.42');
+//        $oss[$n++] = os('Fedora', '44', 'fc44', 'May 2027', '2.43');
         break;
     case OS_OPENSUSE:
         $oss[$n++] = os('openSUSE', '15.4', 'suse15_4', 'December 2023', '2.31');
@@ -166,6 +168,7 @@ sudo yum install boinc-client boinc-manager',
         case '41':
         case '42':
         case '43':
+        case '44':
             $x = sprintf(
 'sudo dnf install dnf-plugins-core
 sudo dnf config-manager addrepo --from-repofile=https://boinc.berkeley.edu/dl/linux/%s/%s/boinc-%s-%s.repo


### PR DESCRIPTION
…

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps Linux alpha to 8.2.10 in linux_install.php and aligns distro info to keep install instructions accurate. Adds Fedora 44 handling in the installer logic, corrects Ubuntu 24.04 support date to April 2029, and comments out future entries for Ubuntu 26.04 and Fedora 44.

<sup>Written for commit ad19a387d0cfd8c5f69a1e1a2279e158934f781f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

