### PR TITLE
Linux release: update alpha version to 8.2.11

### DIFF
--- a/linux_install.php
+++ b/linux_install.php
@@ -5,7 +5,7 @@
 require_once('../inc/util.inc');
 require_once('../inc/clipboard.inc');
 
-$versions = ['stable'=>'8.2.9', 'alpha'=>'8.2.10', 'nightly'=>'8.3.0'];
+$versions = ['stable'=>'8.2.9', 'alpha'=>'8.2.11', 'nightly'=>'8.3.0'];
 
 define('OS_DEBIAN', 0);
 define('OS_UBUNTU', 1);


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updates linux_install.php to set the alpha channel to version 8.2.11. This ensures the Linux installer fetches the latest alpha build.

<sup>Written for commit 32b331841fe6a4698b300291ade9fd37c874f160. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

