### PR TITLE
Download page: if user agent says Win64, show ARM button too

### DIFF
--- a/alpha/test.inc
+++ b/alpha/test.inc
@@ -708,9 +708,10 @@ $screensaver_tests = array(
 // MAKE SURE YOU USE THE APPROPRIATE SET OF TESTS
 //
 $versions = [
-    ["8.2.10", [$general, $clean, $docker], $all_platforms],
+    ["8.2.11", [$general, $clean, $docker], $all_platforms],
 ];
 $old_versions = [
+    ["8.2.10", [$general, $clean, $docker], $all_platforms],
     ["8.2.9", [$general, $clean, $docker], $all_platforms],
     array("8.2.6", [$general, $clean, $docker], $all_platforms),
     array("8.2.5", [$general, $clean, $docker], $all_platforms),

--- a/download.php
+++ b/download.php
@@ -1,5 +1,7 @@
 <?php
 
+// download page for BOINC web site only
+
 // If xml=1 is specified, redirect to download_all.php
 // the client fetches download.php?xml=1 every so often;
 // so don't break this!!!
@@ -54,7 +56,12 @@ function show_download($client_info, $pname) {
         );
 
     } else if ($pname) {
-        download_link($client_info, $pname, true);
+        if ($pname == 'winx64') {
+            download_link($pname, true);
+            download_link('win_arm', true);
+        } else {
+            download_link($pname, true);
+        }
     } else {
         start_table();
         table_header(
@@ -62,16 +69,16 @@ function show_download($client_info, $pname) {
             'BOINC version ',
             'Click to download'
         );
-        download_link($client_info, 'winx64');
-        download_link($client_info, 'win');
-        download_link($client_info, 'mac');
-        download_link($client_info, 'mac_10_7');
-        download_link($client_info, 'mac32');
-        download_link($client_info, 'macppc');
-        //download_link($client_info, 'linux');
-        //download_link($client_info, 'linuxx64');
-        //download_link($client_info, 'linuxcompat');
-        download_link($client_info, 'android');
+        download_link('winx64');
+        download_link('win');
+        download_link('mac');
+        download_link('mac_10_7');
+        download_link('mac32');
+        download_link('macppc');
+        //download_link('linux');
+        //download_link('linuxx64');
+        //download_link('linuxcompat');
+        download_link('android');
         end_table();
         echo "Linux users: <a href=https://github.com/BOINC/boinc/wiki/Installing_on_Linux>see Installation options</a>.";
     }

--- a/download_util.inc
+++ b/download_util.inc
@@ -84,7 +84,10 @@ function client_info_to_platform($client_info) {
     if (strstr($client_info, 'Windows')) {
         if (stristr($client_info, 'arm64')) {
             return 'win_arm';
-        } else if (strstr($client_info, 'x64')||strstr($client_info, 'WOW64')) {
+        } else if (stristr($client_info, 'x64')
+            || stristr($client_info, 'win64')
+            || stristr($client_info, 'WOW64')
+        ) {
             return 'winx64';
         } else {
             return 'win';

--- a/download_util.inc
+++ b/download_util.inc
@@ -19,27 +19,7 @@
 
 // utility functions for download links
 
-if (0) {
-function button_link_vbox(
-    $vbox_url, $long_name, $vbox_size, $boinc_version, $vbox_version
-) {
-    echo sprintf('
-        <a href="%s" class="btn" style="background-color:seagreen; color:white"><font size=+1><u>%s</u></font>
-        <br>%s (%.2f MB)
-        <br><small>(BOINC %s, VirtualBox %s)</small></a>
-        ',
-        $vbox_url,
-        tra("Download BOINC + VirtualBox"),
-        // "for %s" identifies the operating system, e.g. "for Windows"
-        tra("for %1", $long_name),
-        $vbox_size,
-        $boinc_version,
-        $vbox_version
-    );
-}
-}
-
-function button_link($url, $long_name, $size, $boinc_version, $green) {
+function button_link($url, $long_name, $size, $boinc_version, $green=true) {
     echo sprintf('
         <a href="%s" class="btn" %s><font size=+1><u>%s</u></font>
         <br>%s (%.2f MB)
@@ -57,37 +37,16 @@ function button_link($url, $long_name, $size, $boinc_version, $green) {
 
 // Show download link(s) for the given platform,
 // showing version and download size information.
-// Show both VBox and non-VBox links if available.
 //
 function download_link(
-    $client_info,
     $pname,
-    $button=false,
-        // show as button (else table row)
-    $vbox_req=false
-        // if vbox version is available, show only it
+    $button=false       // show as button (else table row)
 ) {
     global $platforms;
     global $url_base;
     $p = $platforms[$pname];
     $v = latest_version($p);
     $file = $v['file'];
-    if (array_key_exists('vbox_file', $v)) {
-        $vbox_file = $v['vbox_file'];
-        $vbox_version = $v['vbox_version'];
-        $vbox_url = $url_base.$vbox_file;
-        $vbox_path = "dl/$vbox_file";
-        $vbox_size = number_format(filesize($vbox_path)/1000000, 2);
-    } else {
-        $vbox_file = null;
-    }
-    if (strstr($client_info, 'Windows NT 4') || strstr($client_info, 'Windows NT 5')) {
-        $vbox_file = null;
-    }
-
-    // May 2025: don't show VBox anymore.
-    // we want to encourage Docker instead
-    $vbox_file = null;
 
     $long_name = $p['name'];
     $num = $v['num'];
@@ -97,24 +56,10 @@ function download_link(
     $size = number_format(filesize($path)/1000000, 2);
 
     if ($button) {
-        if ($vbox_file && !$vbox_req) {
-            echo tra("We recommend that you also install %1 VirtualBox %2, so your computer can work on science projects that require it.", "<a href=https://www.virtualbox.org/>", "</a>");
-            echo " <a href=http://boinc.berkeley.edu/wiki/VirtualBox>";
-            echo tra("Learn more about VirtualBox.");
-            echo "</a>";
-        }
-
         echo "<center>";
 
-        if ($vbox_file) {
-            button_link_vbox(
-                $vbox_url, $long_name, $vbox_size, $num, $vbox_version
-            );
-        }
         echo "<p><p>";
-        if (!$vbox_file || !$vbox_req) {
-            button_link($url, $long_name, $size, $num, !$vbox_file);
-        }
+        button_link($url, $long_name, $size, $num);
         if ($pname == 'mac') {
             echo "<br><br>This version of BOINC requires MacOS 10.13 or later.<br>For older versions of MacOS, go <a href=download_all.php>here</a>.";
         }
@@ -123,14 +68,6 @@ function download_link(
             echo "<p>", linux_info();
         }
     } else {
-        if ($vbox_file) {
-            echo "<tr>
-                <td class=rowlineleft>$long_name</td>
-                <td class=rowline> $num (with Virtualbox $vbox_version)</td>
-                <td class=rowlineright><a href=$vbox_url>Download</a> ($vbox_size MB)</td>
-                </tr>
-            ";
-        }
         echo "<tr>
             <td class=rowlineleft>$long_name</td>
             <td class=rowline> $num</td>
@@ -145,7 +82,9 @@ function download_link(
 //
 function client_info_to_platform($client_info) {
     if (strstr($client_info, 'Windows')) {
-        if (strstr($client_info, 'Win64')||strstr($client_info, 'WOW64')) {
+        if (stristr($client_info, 'arm64')) {
+            return 'win_arm';
+        } else if (strstr($client_info, 'x64')||strstr($client_info, 'WOW64')) {
             return 'winx64';
         } else {
             return 'win';


### PR DESCRIPTION
Fixes #35

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show the Windows ARM download alongside Win64 and auto-detect Windows ARM64 user agents so users land on the right build. Improve Windows UA parsing to better detect x64.

- **New Features**
  - Detect `arm64` in Windows user agents (select `win_arm`) and improve x64 detection (case-insensitive, includes `x64`).
  - When `pname=winx64`, also render a `win_arm` download button.

- **Refactors**
  - Removed all VirtualBox download options and messaging from the download page.
  - Simplified `download_link()` (dropped VBox/client args) and updated callers; `button_link()` now defaults to green styling.
  - Updated test versions: current `8.2.11`; moved `8.2.10` to old.

<sup>Written for commit 25a5ed04a0768cfba76ec6749099c9b30be3f6b3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

