### PR TITLE
Promote 8.2.11 as a stable release on Linux

### DIFF
--- a/linux_install.php
+++ b/linux_install.php
@@ -5,7 +5,7 @@
 require_once('../inc/util.inc');
 require_once('../inc/clipboard.inc');
 
-$versions = ['stable'=>'8.2.9', 'alpha'=>'8.2.11', 'nightly'=>'8.3.0'];
+$versions = ['stable'=>'8.2.11', 'alpha'=>'8.2.11', 'nightly'=>'8.3.0'];
 
 define('OS_DEBIAN', 0);
 define('OS_UBUNTU', 1);
@@ -28,7 +28,7 @@ function get_oss($os_num) {
         $oss[$n++] = os('Ubuntu', '20.04', 'focal', 'April 2025', '2.31');
         $oss[$n++] = os('Ubuntu', '22.04', 'jammy', 'April 2027', '2.35');
         $oss[$n++] = os('Ubuntu', '24.04', 'noble', 'April 2029', '2.39');
-//        $oss[$n++] = os('Ubuntu', '26.04', 'resolute', 'April 2031', '2.42');
+        $oss[$n++] = os('Ubuntu', '26.04', 'resolute', 'April 2031', '2.42');
         break;
     case OS_FEDORA:
         $oss[$n++] = os('Fedora', '37', 'fc37', 'November 2023', '2.36');
@@ -38,7 +38,7 @@ function get_oss($os_num) {
         $oss[$n++] = os('Fedora', '41', 'fc41', 'November 2025', '2.40');
         $oss[$n++] = os('Fedora', '42', 'fc42', 'May 2026', '2.41');
         $oss[$n++] = os('Fedora', '43', 'fc43', 'December 2026', '2.42');
-//        $oss[$n++] = os('Fedora', '44', 'fc44', 'May 2027', '2.43');
+        $oss[$n++] = os('Fedora', '44', 'fc44', 'May 2027', '2.43');
         break;
     case OS_OPENSUSE:
         $oss[$n++] = os('openSUSE', '15.4', 'suse15_4', 'December 2023', '2.31');


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Promotes 8.2.11 to stable for Linux installs and updates the supported distro list. Updates stable from 8.2.9 to 8.2.11 (alpha stays 8.2.11) and enables Ubuntu 26.04 (resolute) and Fedora 44 entries.

<sup>Written for commit ebb8800f29a8127f5b9898434fe4f7516f3b04bc. Summary will update on new commits. <a href="https://cubic.dev/pr/BOINC/boinc-site/pull/37?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

