### PR TITLE
Promote 8.2.12 as a new recommended release for Linux

### DIFF
--- a/linux_install.php
+++ b/linux_install.php
@@ -5,7 +5,7 @@
 require_once('../inc/util.inc');
 require_once('../inc/clipboard.inc');
 
-$versions = ['stable'=>'8.2.11', 'alpha'=>'8.2.11', 'nightly'=>'8.3.0'];
+$versions = ['stable'=>'8.2.12', 'alpha'=>'8.2.12', 'nightly'=>'8.3.0'];
 
 define('OS_DEBIAN', 0);
 define('OS_UBUNTU', 1);


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Promotes 8.2.12 as the recommended Linux release by updating the version map in linux_install.php so users get the new build.
Sets both stable and alpha channels to 8.2.12; nightly remains 8.3.0.

<sup>Written for commit c019be9d442731f27a50b2b2c1d5e79179022b3e. Summary will update on new commits. <a href="https://cubic.dev/pr/BOINC/boinc-site/pull/38?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

