### PR TITLE
Promote 8.2.13 as a stable linux release

### DIFF
--- a/linux_install.php
+++ b/linux_install.php
@@ -5,7 +5,7 @@
 require_once('../inc/util.inc');
 require_once('../inc/clipboard.inc');
 
-$versions = ['stable'=>'8.2.12', 'alpha'=>'8.2.12', 'nightly'=>'8.3.0'];
+$versions = ['stable'=>'8.2.13', 'alpha'=>'8.2.13', 'nightly'=>'8.3.0'];
 
 define('OS_DEBIAN', 0);
 define('OS_UBUNTU', 1);


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Promoted 8.2.13 as the stable Linux release in the installer. Stable and alpha downloads now point to 8.2.13; nightly remains 8.3.0.

<sup>Written for commit d58bb5425ae179bc8c4ea0fee71706ebd9c7caa7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

